### PR TITLE
continue scanning one-liners when use if, autouse or >5.010 found

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -849,7 +849,10 @@ sub scan_line {
                 return if $@ or !defined $module;
             };
             $module =~ s{::}{/}g;
-            return ("$pragma.pm", "$module.pm");
+            #return ("$pragma.pm", "$module.pm");
+            $found{"$pragma.pm"}++;
+            $found{"$module.pm"}++;
+            next CHUNK;
         }
 
         if (my ($how, $libs) = /^(use \s+ lib \s+ | (?:unshift|push) \s+ \@INC \s+ ,) (.+)/x)

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -798,6 +798,7 @@ sub scan_line {
     $line =~ s/\s*#.*$//;
     $line =~ s/[\\\/]+/\//g;
 
+  CHUNK:
     foreach (split(/;/, $line)) {
         s/^\s*//;
 
@@ -811,7 +812,9 @@ sub scan_line {
           # include feature.pm if we have 5.9.5 or better
           if (version->new($1) >= version->new("5.9.5")) {
               # seems to catch 5.9, too (but not 5.9.4)
-            return "feature.pm";
+            #return "feature.pm";
+            $found{"feature.pm"}++;
+            next CHUNK;
           }
         }
 

--- a/t/16-scan_line.t
+++ b/t/16-scan_line.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 use Module::ScanDeps qw/scan_line/;
 
 {
@@ -32,3 +32,18 @@ eval {
 is($@,'');
 }
 
+{  #  use 5.010 on one line was missing later use calls
+  my $chunk = 'use 5.010; use MyModule::PlaceHolder1;';
+  my @got = scan_line($chunk);
+  diag @got;
+  my @expected = sort ('feature.pm', 'MyModule/PlaceHolder1.pm');
+  is_deeply (\@expected, [sort @got], 'got more than just feature.pm when use 5.xx on line');
+}
+
+{  #  use 5.010 on one line was missing later use calls
+  my $chunk = 'use 5.009; use MyModule::PlaceHolder1;';
+  my @got = scan_line($chunk);
+  diag @got;
+  my @expected = sort ('MyModule/PlaceHolder1.pm');
+  is_deeply (\@expected, [sort @got], 'did not get feature.pm when use 5.009 on line');
+}


### PR DESCRIPTION
scan_line was returning early and ignoring %found as soon as it encountered a line containing "use 5.010" (anything greater than v5.9.5), "use if" or "use autouse".

This meant it returned only feature.pm for one-liners such as "use 5.024; use Some::Other::Module".  Similar issues occurred for the if and autouse pragmas.  

There is still an early return when the package keyword is found.  I'm not sure of the best way to handle that, though, as it sets a global $CurrentPackage so I assume it has knock-on effects.  One also expects it to be uncommon in one-liners in the wild.  

