### PR TITLE
Add PerlIO::via to File::BOM preload

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -333,7 +333,7 @@ my %Preload = (
         grep /\bMM_/, _glob_in_inc('ExtUtils', 1);
     },
     'File/Basename.pm'                  => [qw( re.pm )],
-    'File/BOM.pm'                       => [qw( Encode/Unicode.pm )],
+    'File/BOM.pm'                       => [qw( Encode/Unicode.pm PerlIO/via.pm )],
     'File/HomeDir.pm'                   => 'sub',
     'File/Spec.pm'                      => sub {
         require File::Spec;


### PR DESCRIPTION
File::BOM can be used as a layer in open(), e.g. ```open my $fh, '<via(File::BOM)', $somefile;```

However, PerlIO::via is not used in the File::BOM code, so Module::ScanDeps has no way of knowing about it unless the script it is executed and attempts to open a file.  A preload allows support for static scanning.  

Let me know if you want a test for this.  I think none of the preloads have tests, but it perhaps would still be useful.  
