### PR TITLE
Preloads: Add .pm extension to FFFI/Platypus rule

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -333,7 +333,7 @@ my %Preload = (
         grep /\bMM_/, _glob_in_inc('ExtUtils', 1);
     },
     'File/Basename.pm'                  => [qw( re.pm )],
-    'File/BOM.pm'                       => [qw( Encode/Unicode.pm )],
+    'File/BOM.pm'                       => [qw( Encode/Unicode.pm PerlIO/via.pm )],
     'File/HomeDir.pm'                   => 'sub',
     'File/Spec.pm'                      => sub {
         require File::Spec;

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -332,7 +332,7 @@ my %Preload = (
     'ExtUtils/MakeMaker.pm'             => sub {
         grep /\bMM_/, _glob_in_inc('ExtUtils', 1);
     },
-    'FFI/Platypus'                      => 'sub',
+    'FFI/Platypus.pm'                   => 'sub',
     'File/Basename.pm'                  => [qw( re.pm )],
     'File/BOM.pm'                       => [qw( Encode/Unicode.pm PerlIO/via.pm )],
     'File/HomeDir.pm'                   => 'sub',


### PR DESCRIPTION
It might be worth adding a test for the future.  That would need a method to access the preload hash (or a copy of it), so I've held off doing that for now.  
