### PR TITLE
Preloads: Add pm extension to FFI/Platypus rule name

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -332,7 +332,7 @@ my %Preload = (
     'ExtUtils/MakeMaker.pm'             => sub {
         grep /\bMM_/, _glob_in_inc('ExtUtils', 1);
     },
-    'FFI/Platypus'                      => 'sub',
+    'FFI/Platypus.pm'                   => 'sub',
     'File/Basename.pm'                  => [qw( re.pm )],
     'File/BOM.pm'                       => [qw( Encode/Unicode.pm )],
     'File/HomeDir.pm'                   => 'sub',


### PR DESCRIPTION
A test for preload keys ending in .pm would be useful, but that needs a method to access the preload hash so I have held off doing so for this PR.  

Updates #4
