### PR TITLE
Mention some other modules: Module::ExtractUse and Perl::PrereqScanne…

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -1635,6 +1635,10 @@ scripts that contains prerequisite modules; this module supports two
 such projects, L<PAR> and L<App::Packer>.  Please see their respective
 documentations on CPAN for further information.
 
+Other modules which accomplish the same goal with different approach:
+L<Module::ExtractUse>, L<Perl::PrereqScanner>, L<Perl::PrereqScanner::Lite>,
+L<Perl::PrereqScanner::NotQuiteLite>.
+
 =head1 AUTHORS
 
 Audrey Tang E<lt>cpan@audreyt.orgE<gt>


### PR DESCRIPTION
Since Module::ExtractUse mentions this module, perhaps it's a good idea to also mention Module::ExtractUse as well as a few other alternative modules.