### PR TITLE
Process lines like "{ package foo; use if 1, "warnings"; }

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -802,7 +802,8 @@ sub scan_line {
   CHUNK:
     foreach (split(/;/, $line)) {
         s/^\s*//;
-        s/^\{\s*//;  #  handle single line blocks like { package foo; use xx; }
+        #  handle single line blocks like 'do { package foo; use xx; }'
+        s/^(?:do\s*)?\{\s*//;  
         s/\}$//;
 
         if (/^package\s+(\w+)/) {
@@ -917,8 +918,9 @@ sub scan_chunk {
     my $module = eval {
         $_ = $chunk;
         s/^\s*//;
-        s/^\{\s*//;  #  handle single line blocks like { package foo; use xx; }
-        s/\}$//;
+        #  handle single line blocks like 'do { package foo; use xx; }'
+        s/^(?:do\s*)?\{\s*//;  
+        s/\}\s*$//;
 
         # TODO: There's many more of these "loader" type modules on CPAN!
         # scan for the typical module-loader modules

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -802,6 +802,8 @@ sub scan_line {
   CHUNK:
     foreach (split(/;/, $line)) {
         s/^\s*//;
+        s/^\{\s*//;  #  handle single line blocks like { package foo; use xx; }
+        s/\}$//;
 
         if (/^package\s+(\w+)/) {
             $CurrentPackage = $1;
@@ -915,6 +917,8 @@ sub scan_chunk {
     my $module = eval {
         $_ = $chunk;
         s/^\s*//;
+        s/^\{\s*//;  #  handle single line blocks like { package foo; use xx; }
+        s/\}$//;
 
         # TODO: There's many more of these "loader" type modules on CPAN!
         # scan for the typical module-loader modules

--- a/t/16-scan_line.t
+++ b/t/16-scan_line.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 9;
 use Module::ScanDeps qw/scan_line/;
 
 {
@@ -65,3 +65,16 @@ is($@,'');
   is_deeply (\@expected, [sort @got], 'autouse pragma used in one-liner');
 }
 
+
+
+{
+my $chunk= "{ package foo; use if 1, 'warnings' }";
+my @array=sort(scan_line($chunk));
+is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
+}
+
+{
+my $chunk= "{ use if 1, 'warnings' }";
+my @array=sort(scan_line($chunk));
+is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
+}

--- a/t/16-scan_line.t
+++ b/t/16-scan_line.t
@@ -68,25 +68,25 @@ is($@,'');
 
 
 {
-my $chunk= "{ package foo; use if 1, 'warnings' }";
-my @array=sort(scan_line($chunk));
-is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
+  my $chunk= "{ package foo; use if 1, 'warnings' }";
+  my @array=sort(scan_line($chunk));
+  is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
 }
 
 {
-my $chunk= "{ use if 1, 'warnings' }";
-my @array=sort(scan_line($chunk));
-is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
+  my $chunk= "{ use if 1, 'warnings' }";
+  my @array=sort(scan_line($chunk));
+  is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
 }
 
 {
-my $chunk= " do { use if 1, 'warnings' }";
-my @array=sort(scan_line($chunk));
-is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
+  my $chunk= " do { use if 1, 'warnings' }";
+  my @array=sort(scan_line($chunk));
+  is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
 }
 
 {
-my $chunk= " do { use foo }";
-my @array=sort(scan_line($chunk));
-is_deeply(\@array,[sort qw{foo.pm}]);
+  my $chunk= " do { use foo }";
+  my @array=sort(scan_line($chunk));
+  is_deeply(\@array,[sort qw{foo.pm}]);
 }

--- a/t/16-scan_line.t
+++ b/t/16-scan_line.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More tests => 11;
 use Module::ScanDeps qw/scan_line/;
 
 {
@@ -77,4 +77,16 @@ is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
 my $chunk= "{ use if 1, 'warnings' }";
 my @array=sort(scan_line($chunk));
 is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
+}
+
+{
+my $chunk= " do { use if 1, 'warnings' }";
+my @array=sort(scan_line($chunk));
+is_deeply(\@array,[sort qw{if.pm warnings.pm}]);
+}
+
+{
+my $chunk= " do { use foo }";
+my @array=sort(scan_line($chunk));
+is_deeply(\@array,[sort qw{foo.pm}]);
 }


### PR DESCRIPTION
Previously the if module was missed in such cases

As context, Path::Tiny 0.104 had a line that triggered this issue.
```perl
{ package flock; use if Path::Tiny::IS_BSD(), 'warnings::register' }
```
