### PR TITLE
Handle Spreadsheet::ParseODS

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -1020,6 +1020,8 @@ sub scan_chunk {
                 if $args =~ /:encoding\((.*?)\)/;
             push @mods, qw( PerlIO.pm PerlIO/via.pm )
                 if $args =~ /:via\(/;
+            push @mods, qw( PerlIO/gzip.pm )
+                if $args =~ /:gzip\(/;
             return \@mods if @mods;
         }
         if (/\b(?:en|de)code\(\s*['"]?([-\w]+)/) {

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -478,6 +478,11 @@ my %Preload = (
     },
     'Socket/GetAddrInfo.pm'             => 'sub',
     'Specio/PartialDump.pm'             => \&_unicore,
+    'Spreadsheet/ParseODS.pm'           => sub {
+        _glob_in_inc('Class/XSAccessor', 1),
+        _glob_in_inc('XML/XPathEngine',  1),
+        _glob_in_inc('URI/Escape', 1),
+    },
     'SQL/Parser.pm'                     => sub {
         _glob_in_inc('SQL/Dialects', 1);
     },


### PR DESCRIPTION
This PR is to handle dependencies for Spreadsheet::ParseODS.  

The first commit is more generic, and handles cases like ```binmode $fh => ':gzip(none)'```.

The second commit adds specific preloads that are othrwise not detected by static scanning.   