### PR TITLE
scan line: Handle spaces after quote operator 

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -983,7 +983,7 @@ sub scan_chunk {
 
         # "eval" with an expression that's a string literal:
         # analyze the string
-        s/^eval \s+ (?:['"]|qq?\W) \s*//x;
+        s/^eval \s+ (?:['"]|qq?\s*\W) \s*//x;
 
         # TODO: There's many more of these "loader" type modules on CPAN!
         # scan for the typical module-loader modules

--- a/t/16-scan_line.t
+++ b/t/16-scan_line.t
@@ -72,6 +72,18 @@ my @tests = (
         expected => 'Win32/WinError.pm',
     },
     {
+        chunk    => ' eval q(require Win32::WinError; 1);',
+        expected => 'Win32/WinError.pm',
+    },
+    {
+        chunk    => ' eval qq[require Win32::WinError; 1];',
+        expected => 'Win32/WinError.pm',
+    },
+    {
+        chunk    => ' eval qq {require Win32::WinError; 1};',
+        expected => 'Win32/WinError.pm',
+    },
+    {
         chunk    => ' if ( eval "require Win32::WinError; 1" ) {',
         expected => 'Win32/WinError.pm',
     },

--- a/t/16-scan_line.t
+++ b/t/16-scan_line.t
@@ -107,5 +107,5 @@ foreach my $t (@tests)
 {
     my @got = scan_line($t->{chunk});
     my @exp = split(' ', $t->{expected});
-    is_deeply([sort @got], [sort @exp], $t->{comment});
+    is_deeply([sort @got], [sort @exp], $t->{comment} || $t->{chunk});
 }


### PR DESCRIPTION
The updates for #12 handle ```eval qq{Some::Module}``` but not the case where there is a space after the quote operator, e.g. ```eval qq {Some::Module}```.  

This PR fixes that and adds tests for both cases.  

The second commit uses the canned chunk as the test name to make failures easier to interpret.  
