### PR TITLE
scan_line() does not ignore print statements

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -928,6 +928,16 @@ sub scan_line {
             next CHUNK;
         }
 
+        if (/^(?:print|printf|die|warn)/) {
+          # ignore lines of the form
+          #   print "... do ...",
+          #   printf "... do ...",
+          #   die "... do ...",
+          #   warn "... do ...",
+          # since scan_chunk() cannot discern
+          next CHUNK;
+        }
+
         $found{$_}++ for scan_chunk($_);
     }
 

--- a/t/16-scan_line.t
+++ b/t/16-scan_line.t
@@ -95,6 +95,26 @@ my @tests = (
         chunk    => ' if ( eval "require Win32::WinError" ) {',
         expected => 'Win32/WinError.pm',
     },
+    {
+        chunk    => ' print "pausing to do deferred textsearches"',
+        expected => '',
+    },
+    {
+        chunk    => ' printf "pausing to do deferred textsearches";',
+        expected => '',
+    },
+    {
+        chunk    => ' die "this method is very dangerous, if you really want to do it, read the source for caveats";',
+        expected => '',
+    },
+    {
+        chunk    => ' warn "this method is very dangerous, if you really want to do it, read the source for caveats";',
+        expected => '',
+    },
+    {
+        chunk    => ' if ( $arg eq "do count only" ) {',
+        expected => '',
+    },
 );
 
 plan tests => 1+@tests;


### PR DESCRIPTION
good day,
while using this wonderful tool to update and standardize `PREREQ_PM` across our many `Makefile.PL`, i discovered some instances of false positives, mostly involving printed strings with the word 'do' in them.

i have added some test cases as well as a proposed fix. but i consider my fix to be sub-par because it doesn't really get at the root of the issue, it simply avoids problems in some very specific cases. for example, it doesn't cover `say ...` or any other method one might use to render text. it also doesn't cover the failing text case that i included.

basically, i can see that the underlying issue is one of being able to parse certain syntax with a little more granularity, but i could not identify any clean way to make the relevant line(s) more robust based on my perusal of the existing code.

this PR was not intended to be a finished product, but i hope i have provided enough detail, context and clarity of intent. if not, please let me know.