### PR TITLE
Ensure $inc gets removed from the start of $File::Find::name

### DIFF
--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -1234,13 +1234,15 @@ sub _glob_in_inc {
 
     my @files;
     foreach my $inc (grep !/\bBSDPAN\b/, @INC, @IncludeLibs) {
+        $inc =~ s|\\|\/|go;
         my $dir = "$inc/$subdir";
         next unless -d $dir;
         File::Find::find(
             sub {
                 return unless -f $_;
                 return if $pm_only and !/\.p[mh]$/i;
-                (my $name = $File::Find::name) =~ s!^\Q$inc\E/!!;
+                (my $name = $File::Find::name) =~ s|\\|\/|go;
+                $name =~ s!^\Q$inc\E/!!;
                 push @files, $pm_only ? $name
                                       : { file => $File::Find::name, name => $name };
             },


### PR DESCRIPTION
On Windows, if $inc contains backslashes then it won't always get removed from the start of $File::Find::name because the latter may be canonicalized to only contain forward slashes.

Canonicalize both to be sue they match before performing the substitution.

I noticed this when upgrading an old Perl system (5.30.1 to 5.38.0): if $inc was D:\Dev\Temp\Filter-Crypto-2.10\blib\arch then $File::Find::name was being set to values such as D:\Dev\Temp\Filter-Crypto-2.10\blib\arch/auto/Filter/Crypto/Decrypt/Decrypt.dll and all was well, but now $File::Find::name is set to values such as
D:/Dev/Temp/Filter-Crypto-2.10/blib/arch/auto/Filter/Crypto/Decrypt/Decrypt.dll so $inc didn't get removed.