### PR TITLE
faster add_deps on case insensitive systems

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ WriteMakefile1(
       'Module::Metadata' => 0,
       'Text::ParseWords' => 0,
       'version'          => 0,
+      'List::Util' => '1.33',
     },
     TEST_REQUIRES   => {
       'Test::More'       => 0,

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -1153,20 +1153,24 @@ sub _add_info {
     # Avoid duplicates that can arise due to case differences that don't actually
     # matter on a case tolerant system
     if (is_insensitive_fs) {
-        foreach my $key (keys %$rv) {
-            if (lc($key) eq lc($module)) {
-                $module = $key;
-                last;
+        if (!exists $rv->{$module}) {
+            foreach my $key (keys %$rv) {
+                if (lc($key) eq lc($module)) {
+                    $module = $key;
+                    last;
+                }
             }
         }
         if (defined($used_by)) {
             if (lc($used_by) eq lc($module)) {
                 $used_by = $module;
             } else {
-                foreach my $key (keys %$rv) {
-                    if (lc($key) eq lc($used_by)) {
-                        $used_by = $key;
-                        last;
+                if (!exists $rv->{$used_by}) {
+                    foreach my $key (keys %$rv) {
+                        if (lc($key) eq lc($used_by)) {
+                            $used_by = $key;
+                            last;
+                        }
                     }
                 }
             }

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -1154,8 +1154,9 @@ sub _add_info {
     # matter on a case tolerant system
     if (is_insensitive_fs) {
         if (!exists $rv->{$module}) {
+            my $lc_module  = lc $module;
             foreach my $key (keys %$rv) {
-                if (lc($key) eq lc($module)) {
+                if (lc($key) eq $lc_module) {
                     $module = $key;
                     last;
                 }
@@ -1166,8 +1167,9 @@ sub _add_info {
                 $used_by = $module;
             } else {
                 if (!exists $rv->{$used_by}) {
+                    my $lc_used_by = lc $used_by;
                     foreach my $key (keys %$rv) {
-                        if (lc($key) eq lc($used_by)) {
+                        if (lc($key) eq $lc_used_by) {
                             $used_by = $key;
                             last;
                         }
@@ -1185,11 +1187,13 @@ sub _add_info {
 
     if (defined($used_by) and $used_by ne $module) {
         if (is_insensitive_fs) {
+            my $lc_used_by = lc $used_by;
+            my $lc_module  = lc $module;
             push @{ $rv->{$module}{used_by} }, $used_by
-                if !grep { lc($_) eq lc($used_by) } @{ $rv->{$module}{used_by} };
+                if !grep { lc($_) eq $lc_used_by } @{ $rv->{$module}{used_by} };
             # We assume here that another _add_info will be called to provide the other parts of $rv->{$used_by}
             push @{ $rv->{$used_by}{uses} }, $module
-                if !grep { lc($_) eq lc($module) } @{ $rv->{$used_by}{uses} };
+                if !grep { lc($_) eq $lc_module } @{ $rv->{$used_by}{uses} };
         }
         else {
             push @{ $rv->{$module}{used_by} }, $used_by

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -1184,14 +1184,20 @@ sub _add_info {
     };
 
     if (defined($used_by) and $used_by ne $module) {
-        push @{ $rv->{$module}{used_by} }, $used_by
-          if  ( (!is_insensitive_fs && !grep { $_ eq $used_by } @{ $rv->{$module}{used_by} })
-             or ( is_insensitive_fs && !grep { lc($_) eq lc($used_by) } @{ $rv->{$module}{used_by} }));
-
-        # We assume here that another _add_info will be called to provide the other parts of $rv->{$used_by}
-        push @{ $rv->{$used_by}{uses} }, $module
-          if  ( (!is_insensitive_fs && !grep { $_ eq $module } @{ $rv->{$used_by}{uses} })
-             or ( is_insensitive_fs && !grep { lc($_) eq lc($module) } @{ $rv->{$used_by}{uses} }));
+        if (is_insensitive_fs) {
+            push @{ $rv->{$module}{used_by} }, $used_by
+                if !grep { lc($_) eq lc($used_by) } @{ $rv->{$module}{used_by} };
+            # We assume here that another _add_info will be called to provide the other parts of $rv->{$used_by}
+            push @{ $rv->{$used_by}{uses} }, $module
+                if !grep { lc($_) eq lc($module) } @{ $rv->{$used_by}{uses} };
+        }
+        else {
+            push @{ $rv->{$module}{used_by} }, $used_by
+                if !grep { $_ eq $used_by } @{ $rv->{$module}{used_by} };
+            # We assume here that another _add_info will be called to provide the other parts of $rv->{$used_by}
+            push @{ $rv->{$used_by}{uses} }, $module
+                if !grep { $_ eq $module } @{ $rv->{$used_by}{uses} };
+        }
     }
 }
 

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -17,7 +17,7 @@ use File::Path ();
 use File::Temp ();
 use FileHandle;
 use Module::Metadata;
-use List::Util qw ( any );
+use List::Util qw ( any first );
 
 # NOTE: Keep the following imports exactly as specified, even if the Module::ScanDeps source
 # doesn't reference some of them. See '"use lib" idioms' for the reason.
@@ -1156,12 +1156,10 @@ sub _add_info {
     if (is_insensitive_fs) {
         if (!exists $rv->{$module}) {
             my $lc_module  = lc $module;
-            foreach my $key (keys %$rv) {
-                if (lc($key) eq $lc_module) {
-                    $module = $key;
-                    last;
-                }
-            }
+            my $key = first {lc($_) eq $lc_module} keys %$rv;
+            if (defined $key) {
+                $module = $key
+            };
         }
         if (defined($used_by)) {
             if (lc($used_by) eq lc($module)) {
@@ -1169,12 +1167,10 @@ sub _add_info {
             } else {
                 if (!exists $rv->{$used_by}) {
                     my $lc_used_by = lc $used_by;
-                    foreach my $key (keys %$rv) {
-                        if (lc($key) eq $lc_used_by) {
-                            $used_by = $key;
-                            last;
-                        }
-                    }
+                    my $key = first {lc($_) eq $lc_used_by} keys %$rv;
+                    if (defined $key) {
+                        $used_by = $key
+                    };
                 }
             }
         }

--- a/lib/Module/ScanDeps.pm
+++ b/lib/Module/ScanDeps.pm
@@ -17,6 +17,7 @@ use File::Path ();
 use File::Temp ();
 use FileHandle;
 use Module::Metadata;
+use List::Util qw ( any );
 
 # NOTE: Keep the following imports exactly as specified, even if the Module::ScanDeps source
 # doesn't reference some of them. See '"use lib" idioms' for the reason.
@@ -1190,17 +1191,17 @@ sub _add_info {
             my $lc_used_by = lc $used_by;
             my $lc_module  = lc $module;
             push @{ $rv->{$module}{used_by} }, $used_by
-                if !grep { lc($_) eq $lc_used_by } @{ $rv->{$module}{used_by} };
+                if !any { lc($_) eq $lc_used_by } @{ $rv->{$module}{used_by} };
             # We assume here that another _add_info will be called to provide the other parts of $rv->{$used_by}
             push @{ $rv->{$used_by}{uses} }, $module
-                if !grep { lc($_) eq $lc_module } @{ $rv->{$used_by}{uses} };
+                if !any { lc($_) eq $lc_module } @{ $rv->{$used_by}{uses} };
         }
         else {
             push @{ $rv->{$module}{used_by} }, $used_by
-                if !grep { $_ eq $used_by } @{ $rv->{$module}{used_by} };
+                if !any { $_ eq $used_by } @{ $rv->{$module}{used_by} };
             # We assume here that another _add_info will be called to provide the other parts of $rv->{$used_by}
             push @{ $rv->{$used_by}{uses} }, $module
-                if !grep { $_ eq $module } @{ $rv->{$used_by}{uses} };
+                if !any { $_ eq $module } @{ $rv->{$used_by}{uses} };
         }
     }
 }


### PR DESCRIPTION
Updates #21 

The second two commits are not essential but still help.  They can be elided if deemed unnecessary.  

Commit 3 makes things slightly more readable compared with the relatively dense postfix conditionals.

Commit 4 avoids repeated lc calls.  lc is is fast but calculating it once saves reasonable amounts of time when scanning large codebases under profiling (~12s to ~6s).  This adds up when iterating a build system, for example. 

